### PR TITLE
fix: boot time

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1637,7 +1637,7 @@
                 <key>ProvideCurrentCpuInfo</key>
                 <true/>
                 <key>SetApfsTrimTimeout</key>
-                <integer>-1</integer>
+                <integer>0</integer>
                 <key>ThirdPartyDrives</key>
                 <false/>
                 <key>XhciPortLimit</key>
@@ -1940,23 +1940,23 @@
                 <key>AdviseFeatures</key>
                 <false/>
                 <key>MLB</key>
-                <string>C022333104NPHC1AD</string>
+                <string>C02136500QXP8PGJC</string>
                 <key>MaxBIOSVersion</key>
                 <false/>
                 <key>ProcessorType</key>
                 <integer>0</integer>
                 <key>ROM</key>
-                <data>rBjlNBMX</data>
+                <data>t6LKKwDw</data>
                 <key>SpoofVendor</key>
                 <true/>
                 <key>SystemMemoryStatus</key>
                 <string>Auto</string>
                 <key>SystemProductName</key>
-                <string>iMac20,1</string>
+                <string>MacBookPro16,2</string>
                 <key>SystemSerialNumber</key>
-                <string>C02J7ZZRPN5T</string>
+                <string>C02GCUYBML7H</string>
                 <key>SystemUUID</key>
-                <string>86569E91-0758-49DA-AB9C-5BE8AA023BE5</string>
+                <string>D85AC48F-CA30-4640-A43E-C9AB5BBF7E2C</string>
             </dict>
             <key>UpdateDataHub</key>
             <true/>


### PR DESCRIPTION
It depends on your SSD type. See. https://github.com/dortania/bugtracker/issues/192


## Before

Default `SetApfsTrimTimeout = -1` or `SetApfsTrimTimeout = 1`

![Screenshot 2024-05-09 at 2 58 44 PM](https://github.com/saeidex/ryzentosh-msi-modern-15/assets/112776380/56041636-a965-485d-9d98-1d575dac7837)

## After

Off `SetApfsTrimTimeout = 0'

![Screenshot 2024-05-09 at 3 11 37 PM](https://github.com/saeidex/ryzentosh-msi-modern-15/assets/112776380/d4429dec-9f2e-43ba-a247-28e9fbd9e961)

also check this:
https://www.reddit.com/r/hackintosh/comments/vitefh/does_setapfstrimtimeout0_will_kill_my_ssd/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button